### PR TITLE
Update annotate_neo_termini function

### DIFF
--- a/R/annotate_neo_termini.R
+++ b/R/annotate_neo_termini.R
@@ -437,10 +437,18 @@ categ2_pept_canannot <- bind_rows(pept_wmatch,
     )
 
 final_annotated_df <- left_join(
-    annotated_df_w_quant %>% dplyr::rename(peptide_start = start_position, peptide_end = end_position),
+    annotated_df_w_quant %>% dplyr::rename(
+      peptide_start = start_position, 
+      peptide_end = end_position),
     categ2_pept_canannot,
     relationship = "many-to-many"
     ) %>%
+  mutate(
+    uniprot_processing_type = case_when(
+      is.na(matches_p1_prime) ~ "not_canonical_no_procc_annot",
+      TRUE ~ uniprot_processing_type
+    )
+  )
   dplyr::relocate(
     nterm_modif_peptide,
     nterm_modif,

--- a/R/annotate_neo_termini.R
+++ b/R/annotate_neo_termini.R
@@ -361,8 +361,8 @@ categ_canon_annot <- nter_pepts_n_feat %>%
       matches_p1_prime == TRUE & type == "PROPEP" ~ "PROPEP",
       matches_p1_prime == TRUE & type == "PEPTIDE" ~ "PEPTIDE",
       matches_p1_prime == FALSE ~ "not_canonical",
-      is.na(matches_p1_prime) ~ "not_canonical_no_procc_annot", 
-      TRUE ~ "not_canonical"
+      is.na(matches_p1_prime) ~ "not_canonical_no_procc_annot",
+      TRUE ~ "not_canonical_no_procc_annot"
     )
   ) %>%
   # select interesting columns

--- a/R/annotate_neo_termini.R
+++ b/R/annotate_neo_termini.R
@@ -271,11 +271,13 @@ protein_nter <- bind_rows(
   )
 
 # vector of interesting feature types as annotated by the uniprot API
-mol_processing_feat <- c("INIT_MET",
-                         "PROPEP",
-                         "SIGNAL",
-                         "TRANSIT",
-                         "CHAIN")
+mol_processing_feat <- c(
+  "INIT_MET",
+  "PROPEP",
+  "SIGNAL",
+  "TRANSIT",
+  "CHAIN"
+  )
 
 expected_organisms <- c(
   "mouse",
@@ -330,8 +332,8 @@ if(organism == "mouse"){
 
 df_mol_proc_feat <- uniprot_processing %>%
   dplyr::filter(
-    type %in% mol_processing_feat, # keep only interesting features
-                !is.na(length)) %>% # exclude features with missing values
+    type %in% mol_processing_feat)#, # keep only interesting features
+                #!is.na(length)) %>% # exclude features with missing values
   dplyr::rename(protein = accession)  # change column name
 
 nter_pepts_n_feat <- left_join(
@@ -349,7 +351,7 @@ categ_canon_annot <- nter_pepts_n_feat %>%
         TRUE ~ FALSE
         )
         ) %>%
-  dplyr::filter(!is.na(type)) %>% # eliminate proteins with no processing features annotated
+  #dplyr::filter(!is.na(type)) %>% # eliminate proteins with no processing features annotated
   mutate(
     processing_type = case_when(
       matches_p1_prime == TRUE & type == "CHAIN" ~ "CHAIN",
@@ -358,7 +360,7 @@ categ_canon_annot <- nter_pepts_n_feat %>%
       matches_p1_prime == TRUE & type == "TRANSIT" ~ "TRANSIT",
       matches_p1_prime == TRUE & type == "PROPEP" ~ "PROPEP",
       matches_p1_prime == TRUE & type == "PEPTIDE" ~ "PEPTIDE",
-      #matches_p1_prime == FALSE ~ "not_canonical",
+      matches_p1_prime == FALSE ~ "not_canonical",
       is.na(matches_p1_prime) ~ "not_canonical_no_procc_annot", 
       TRUE ~ "not_canonical"
     )

--- a/R/annotate_neo_termini.R
+++ b/R/annotate_neo_termini.R
@@ -448,7 +448,7 @@ final_annotated_df <- left_join(
       is.na(matches_p1_prime) ~ "not_canonical_no_procc_annot",
       TRUE ~ uniprot_processing_type
     )
-  )
+  ) %>%
   dplyr::relocate(
     nterm_modif_peptide,
     nterm_modif,

--- a/R/annotate_neo_termini.R
+++ b/R/annotate_neo_termini.R
@@ -332,7 +332,7 @@ if(organism == "mouse"){
 
 df_mol_proc_feat <- uniprot_processing %>%
   dplyr::filter(
-    type %in% mol_processing_feat)#, # keep only interesting features
+    type %in% mol_processing_feat) %>% #, # keep only interesting features
                 #!is.na(length)) %>% # exclude features with missing values
   dplyr::rename(protein = accession)  # change column name
 


### PR DESCRIPTION
modify the annotate_neo_termini function to be able to handle proteins without processing features annotated. A new category was added for this kind of features mapping to proteins without annotation.